### PR TITLE
Fix callback registration with missing components

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,39 @@
+Repository Overview
+Main code resides in Python modules under modules/ and modules_forge/.
+
+Tests are located primarily in extensions-builtin/adetailer/tests/.
+
+Documentation lives in docs/, with docs/WILDCARDS.md explaining wildcard prompt parsing.
+
+Working Guidelines
+Run existing tests
+Execute pytest -q from the repository root. Note that some tests may require additional dependencies.
+
+Style and Linting
+
+The project uses Ruff (see pyproject.toml) for linting.
+
+Apply ruff --fix before committing to auto-correct trivial issues.
+
+Commit Etiquette
+
+Keep commit messages concise and descriptive.
+
+Ensure the working directory is clean (git status should show no changes) before submitting a pull request.
+
+Documentation Updates
+
+Update README.md or files under docs/ whenever new functionality or command-line options are introduced.
+
+If the change affects wildcard handling or prompt parsing, also revise docs/WILDCARDS.md.
+
+Testing Additions
+
+When adding new functionality, supplement it with unit tests in extensions-builtin/adetailer/tests/ or create new test modules as appropriate.
+
+Non-Versioned Data
+
+Generated gallery images and metadata are written under the gallery/ directory.
+
+The directory is automatically added to .gitignore by modules/gallery_saver.py; ensure gallery data is never committed.
+

--- a/extensions-builtin/sd_forge_controlnet/lib_controlnet/controlnet_ui/controlnet_ui_group.py
+++ b/extensions-builtin/sd_forge_controlnet/lib_controlnet/controlnet_ui/controlnet_ui_group.py
@@ -1,12 +1,10 @@
 import json
 import gradio as gr
-import functools
-from copy import copy
-from typing import List, Optional, Union, Callable, Dict, Tuple, Literal
+from typing import List, Optional
 from dataclasses import dataclass
 import numpy as np
 
-from lib_controlnet.utils import svg_preprocess, read_image, judge_image_type
+from lib_controlnet.utils import judge_image_type
 from lib_controlnet import (
     global_state,
     external_code,
@@ -15,7 +13,7 @@ from lib_controlnet.logging import logger
 from lib_controlnet.controlnet_ui.openpose_editor import OpenposeEditor
 from lib_controlnet.controlnet_ui.photopea import Photopea
 from lib_controlnet.enums import InputMode, HiResFixOption
-from modules import shared, script_callbacks
+from modules import shared
 from modules.ui_components import FormRow
 from modules_forge.utils import HWC3
 from lib_controlnet.external_code import UiControlNetUnit
@@ -425,7 +423,7 @@ class ControlNetUiGroup(object):
         with gr.Row(elem_classes=["controlnet_control_type", "controlnet_row"]):
             self.type_filter = gr.Radio(
                 global_state.get_all_preprocessor_tags(),
-                label=f"Control Type",
+                label="Control Type",
                 value="All",
                 elem_id=f"{elem_id_tabname}_{tabname}_controlnet_type_filter_radio",
                 elem_classes="controlnet_control_type_filter_group",
@@ -434,7 +432,7 @@ class ControlNetUiGroup(object):
         with gr.Row(elem_classes=["controlnet_preprocessor_model", "controlnet_row"]):
             self.module = gr.Dropdown(
                 global_state.get_all_preprocessor_names(),
-                label=f"Preprocessor",
+                label="Preprocessor",
                 value=self.default_unit.module,
                 elem_id=f"{elem_id_tabname}_{tabname}_controlnet_preprocessor_dropdown",
             )
@@ -447,7 +445,7 @@ class ControlNetUiGroup(object):
             )
             self.model = gr.Dropdown(
                 global_state.get_all_controlnet_names(),
-                label=f"Model",
+                label="Model",
                 value=self.default_unit.model,
                 elem_id=f"{elem_id_tabname}_{tabname}_controlnet_model_dropdown",
             )
@@ -460,7 +458,7 @@ class ControlNetUiGroup(object):
 
         with gr.Row(elem_classes=["controlnet_weight_steps", "controlnet_row"]):
             self.weight = gr.Slider(
-                label=f"Control Weight",
+                label="Control Weight",
                 value=self.default_unit.weight,
                 minimum=0.0,
                 maximum=2.0,
@@ -806,20 +804,26 @@ class ControlNetUiGroup(object):
                 *self.openpose_editor.update(json_acceptor.value),
             )
 
+        inputs = [
+            getattr(self.image, "background", None),
+            getattr(self.image, "foreground", None),
+            self.module,
+            self.processor_res,
+            self.threshold_a,
+            self.threshold_b,
+            self.width_slider,
+            self.height_slider,
+            self.pixel_perfect,
+            self.resize_mode,
+        ]
+
+        if self.trigger_preprocessor is None or any(i is None for i in inputs) or self.generated_image is None:
+            logger.warning("Skipping register_run_annotator due to missing components")
+            return
+
         self.trigger_preprocessor.click(
             fn=run_annotator,
-            inputs=[
-                self.image.background,
-                self.image.foreground,
-                self.module,
-                self.processor_res,
-                self.threshold_a,
-                self.threshold_b,
-                self.width_slider,
-                self.height_slider,
-                self.pixel_perfect,
-                self.resize_mode,
-            ],
+            inputs=inputs,
             outputs=[
                 self.generated_image.block,
                 self.generated_image.background,

--- a/modules/infotext_utils.py
+++ b/modules/infotext_utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import base64
 import io
 import json
+import logging
 import os
 import re
 import sys
@@ -12,6 +13,9 @@ from modules import shared, ui_tempdir, script_callbacks, processing, infotext_v
 from PIL import Image
 
 from modules_forge import main_entry
+from ast import literal_eval
+
+logger = logging.getLogger(__name__)
 
 sys.modules['modules.generation_parameters_copypaste'] = sys.modules[__name__]  # alias for old name
 
@@ -46,7 +50,12 @@ class PasteField(tuple):
         self.function = target if callable(target) else None
 
 
-paste_fields: dict[str, dict] = {}
+paste_fields: dict[str, dict] = {
+    "txt2img": {"init_img": None, "fields": [], "override_settings_component": None},
+    "img2img": {"init_img": None, "fields": [], "override_settings_component": None},
+    "inpaint": {"init_img": None, "fields": [], "override_settings_component": None},
+    "extras": {"init_img": None, "fields": [], "override_settings_component": None},
+}
 registered_param_bindings: list[ParamBinding] = []
 
 # Fields used by UI tabs for pasting generation parameters. These are
@@ -59,6 +68,12 @@ img2img_paste_fields: list[PasteField] = []
 
 def reset():
     paste_fields.clear()
+    paste_fields.update({
+        "txt2img": {"init_img": None, "fields": [], "override_settings_component": None},
+        "img2img": {"init_img": None, "fields": [], "override_settings_component": None},
+        "inpaint": {"init_img": None, "fields": [], "override_settings_component": None},
+        "extras": {"init_img": None, "fields": [], "override_settings_component": None},
+    })
     registered_param_bindings.clear()
 
 
@@ -158,9 +173,14 @@ def register_paste_params_button(binding: ParamBinding):
 
 def connect_paste_params_buttons():
     for binding in registered_param_bindings:
-        destination_image_component = paste_fields[binding.tabname]["init_img"]
-        fields = paste_fields[binding.tabname]["fields"]
-        override_settings_component = binding.override_settings_component or paste_fields[binding.tabname]["override_settings_component"]
+        tab_fields = paste_fields.get(binding.tabname)
+        if tab_fields is None:
+            logger.warning("No paste fields registered for %s", binding.tabname)
+            continue
+
+        destination_image_component = tab_fields["init_img"]
+        fields = tab_fields["fields"]
+        override_settings_component = binding.override_settings_component or tab_fields["override_settings_component"]
 
         destination_width_component = next(iter([field for field, name in fields if name == "Size-1"] if fields else []), None)
         destination_height_component = next(iter([field for field, name in fields if name == "Size-2"] if fields else []), None)
@@ -187,12 +207,16 @@ def connect_paste_params_buttons():
 
         if binding.source_tabname is not None and fields is not None:
             paste_field_names = ['Prompt', 'Negative prompt', 'Steps', 'Face restoration'] + (["Seed"] if shared.opts.send_seed else []) + binding.paste_field_names
-            binding.paste_button.click(
-                fn=lambda *x: x,
-                inputs=[field for field, name in paste_fields[binding.source_tabname]["fields"] if name in paste_field_names],
-                outputs=[field for field, name in fields if name in paste_field_names],
-                show_progress=False,
-            )
+            source_fields = paste_fields.get(binding.source_tabname, {}).get("fields")
+            if source_fields is None:
+                logger.warning("No paste fields registered for %s", binding.source_tabname)
+            else:
+                binding.paste_button.click(
+                    fn=lambda *x: x,
+                    inputs=[field for field, name in source_fields if name in paste_field_names],
+                    outputs=[field for field, name in fields if name in paste_field_names],
+                    show_progress=False,
+                )
 
         binding.paste_button.click(
             fn=None,
@@ -498,7 +522,6 @@ infotext_to_setting_name_mapping = [
     ('Schedule type', 'k_sched_type'),
 ]
 """
-from ast import literal_eval
 def create_override_settings_dict(text_pairs):
     """creates processing's override_settings parameters from gradio's multiselect
 

--- a/modules_forge/main_entry.py
+++ b/modules_forge/main_entry.py
@@ -1,4 +1,5 @@
 import os
+import logging
 import torch
 import gradio as gr
 
@@ -10,6 +11,7 @@ from modules.shared import cmd_opts
 
 
 total_vram = int(memory_management.total_vram)
+logger = logging.getLogger(__name__)
 
 ui_forge_preset: gr.Radio = None
 
@@ -85,7 +87,7 @@ def make_checkpoint_manager_ui():
         a, b = refresh_models()
         return gr.update(choices=a), gr.update(choices=b)
 
-    refresh_button = ui_common.ToolButton(value=ui_common.refresh_symbol, elem_id=f"forge_refresh_checkpoint", tooltip="Refresh")
+    refresh_button = ui_common.ToolButton(value=ui_common.refresh_symbol, elem_id="forge_refresh_checkpoint", tooltip="Refresh")
     refresh_button.click(
         fn=gr_refresh_models,
         inputs=[],
@@ -146,7 +148,7 @@ def refresh_models():
     file_extensions = ['ckpt', 'pt', 'bin', 'safetensors', 'gguf']
 
     module_list.clear()
-    
+
     module_paths = [
         os.path.abspath(os.path.join(paths.models_path, "VAE")),
         os.path.abspath(os.path.join(paths.models_path, "text_encoder")),
@@ -262,7 +264,7 @@ def modules_change(module_values:list, save=True, refresh=True) -> bool:
         module_name = os.path.basename(v) # If the input is a filepath, extract the file name
         if module_name in module_list:
             modules.append(module_list[module_name])
-    
+
     # skip further processing if value unchanged
     if sorted(modules) == sorted(shared.opts.data.get('forge_additional_modules', [])):
         return False
@@ -277,10 +279,12 @@ def modules_change(module_values:list, save=True, refresh=True) -> bool:
 
 
 def get_a1111_ui_component(tab, label):
-    fields = infotext_utils.paste_fields[tab]['fields']
+    fields = infotext_utils.paste_fields.get(tab, {}).get('fields', [])
     for f in fields:
-        if f.label == label or f.api == label:
+        if getattr(f, 'label', None) == label or getattr(f, 'api', None) == label:
             return f.component
+    logger.warning("UI component %s for tab %s not found", label, tab)
+    return None
 
 
 def forge_main_entry():
@@ -324,9 +328,18 @@ def forge_main_entry():
         ui_txt2img_hr_distilled_cfg,
     ]
 
-    ui_forge_preset.change(on_preset_change, inputs=[ui_forge_preset], outputs=output_targets, queue=False, show_progress=False)
-    ui_forge_preset.change(js="clickLoraRefresh", fn=None, queue=False, show_progress=False)
-    Context.root_block.load(on_preset_change, inputs=None, outputs=output_targets, queue=False, show_progress=False)
+    # Filter out components that failed to load
+    missing_components = len([c for c in output_targets if c is None])
+    output_targets = [c for c in output_targets if c is not None]
+    if missing_components:
+        logger.warning("%d preset UI components missing", missing_components)
+
+    if output_targets:
+        ui_forge_preset.change(on_preset_change, inputs=[ui_forge_preset], outputs=output_targets, queue=False, show_progress=False)
+        ui_forge_preset.change(js="clickLoraRefresh", fn=None, queue=False, show_progress=False)
+        Context.root_block.load(on_preset_change, inputs=None, outputs=output_targets, queue=False, show_progress=False)
+    else:
+        logger.warning("No preset UI components available; preset change callbacks not registered")
 
     refresh_model_loading_parameters()
     return


### PR DESCRIPTION
## Summary
- skip annotator registration when required widgets are missing
- ensure preset callbacks only register when components are present
- clean up imports in ControlNet UI module

## Testing
- `ruff check --fix modules_forge/main_entry.py modules/infotext_utils.py modules/gradio_extensions.py extensions-builtin/sd_forge_controlnet/lib_controlnet/controlnet_ui/controlnet_ui_group.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_68416bd5986c832f81ffd4594a836d3e